### PR TITLE
Autodetect if token has prefix

### DIFF
--- a/Model/NotificationContentModel.php
+++ b/Model/NotificationContentModel.php
@@ -77,7 +77,10 @@ class NotificationContentModel
      */
     public function setTo(string $token)
     {
-        $this->to = self::EXPO_TOKEN_PREFIX . $token . self::EXPO_TOKEN_SUFFIX;
+        $this->to = $token;
+        if (!preg_match('/^'.preg_quote(self::EXPO_TOKEN_PREFIX, '/').'.*'.preg_quote(self::EXPO_TOKEN_SUFFIX, '/').'$/', $token)) {
+            $this->to = self::EXPO_TOKEN_PREFIX . $token . self::EXPO_TOKEN_SUFFIX;
+        }
 
         return $this;
     }

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
 		}
 	],
 	"require": {
-		"php":                                ">=5.6",
+		"php":                                ">=7.0",
 		"eightpoints/guzzle-bundle":		  "^6.0",
 		"guzzlehttp/guzzle":                  "~6.0",
 		"eightpoints/guzzle-wsse-middleware": "~4.0",


### PR DESCRIPTION
It's a small change allowing the client to pass the token with or without the Expo prefix. Also, PHP version was bumped to 7.0 to allow scalar type hints used in the bundle (they don't work in 5.6).